### PR TITLE
Improve FSM test coverage

### DIFF
--- a/FSM.async.test.js
+++ b/FSM.async.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import FSM from './FSM.js'
+
+const wait = ms => new Promise(r => setTimeout(r, ms))
+
+describe('FSM async behaviour', () => {
+  it('awaits async handlers and returns value from enter', async () => {
+    const calls = []
+    const fsm = new FSM({
+      initial: 'one',
+      states: {
+        one: {
+          async enter() { calls.push('enter1'); return 'one' },
+          async exit() { await wait(5); calls.push('exit1') },
+          async update() { calls.push('update1') },
+          on: { go: 'two' }
+        },
+        two: {
+          async enter() { calls.push('enter2'); return 'two' }
+        }
+      }
+    })
+
+    await fsm.update()
+    const ret = await fsm.act('go')
+    assert.strictEqual(ret, 'two')
+    assert.deepStrictEqual(calls, ['enter1', 'update1', 'exit1', 'enter2'])
+  })
+
+  it('falls back to action name as state key', async () => {
+    const states = {
+      a: {},
+      b: {}
+    }
+    const fsm = new FSM({
+      initial: 'a',
+      states
+    })
+    await fsm.act('b')
+    assert.strictEqual(fsm.current, states.b)
+  })
+})

--- a/demo.config.js
+++ b/demo.config.js
@@ -2,8 +2,8 @@ const config = {
   initial: 'idle',
   states: {
     idle: {
-      enter: () =>'idle',
-      update: ()=>console.log('idling'),
+      enter: () => 'idle',
+      update: () => console.log('idling'),
       exit: () => console.log('un-idle'),
       on: {
         start: 'running',
@@ -11,8 +11,8 @@ const config = {
       },
     },
     running: {
-      enter: () =>'run',
-      // update: ()=>console.log('running'),
+      enter: () => 'run',
+      // update: () => console.log('running'),
       exit: () => console.log('un-run'),
       on: {
         stop: 'idle',
@@ -20,8 +20,8 @@ const config = {
       },
     },
     paused: {
-      enter: () =>'pause',
-      update: ()=>console.log('paused'),
+      enter: () => 'pause',
+      update: () => console.log('paused'),
       exit: () => console.log('un-pause'),
       on: {
         resume: 'running',
@@ -30,6 +30,5 @@ const config = {
     },
   },
 }
-
 
 export default config

--- a/demo.js
+++ b/demo.js
@@ -1,5 +1,5 @@
 import FSM from './StateMachine.js'
-import config from './test.config.js'
+import config from './demo.config.js'
 
 const fsm = new FSM(config)
 

--- a/package.json
+++ b/package.json
@@ -5,13 +5,12 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test:raw": "node test.js",
-    "test": "vitest"
+    "test:raw": "node demo.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "vitest": "^3.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- convert Vitest suite to use built-in `node:test`
- add new async machine tests
- rename demo files and update package.json

## Testing
- `npm test --silent`
- `node --test --experimental-test-coverage`